### PR TITLE
fix: existing id error and incorrect behaviour

### DIFF
--- a/categories/food/fruit.json
+++ b/categories/food/fruit.json
@@ -1,6 +1,6 @@
 {
   "id": "c34976de-3973-474c-a3e7-727b523be171",
-  "parent": null,
+  "parent": "9961ed43-919d-4d4a-86d9-92688dc2e12d",
   "name": "fruit",
   "attributes": [
     {

--- a/categories/food/fruit/pear.json
+++ b/categories/food/fruit/pear.json
@@ -1,8 +1,8 @@
 {
   "id": "fb8ac0bf-dd1c-4129-bd31-5d8c7528a03b",
-  "parent": null,
+  "parent": "c34976de-3973-474c-a3e7-727b523be171",
   "name": "pear",
-  "selectable_as_last": false,
+  "selectable_as_last": true,
   "attributes": [
     {
       "id": "c3ad4a80-b290-433a-b1f7-2db0c6d26007",

--- a/src/categories/category_id_generator.rs
+++ b/src/categories/category_id_generator.rs
@@ -21,7 +21,7 @@ pub fn set_random_id(source_category: &mut SourceCategory) -> Result<(), Error> 
     match source_category.id {
         Some(_) => Err(Error::new(
             ErrorKind::CannotOverrideId,
-            "Category already has an id",
+            format!("category '{}' already has an id", source_category.name).as_str(),
         )),
         None => {
             let id = Uuid::new_v4();

--- a/src/categories/validations/selectable_as_last_validation.rs
+++ b/src/categories/validations/selectable_as_last_validation.rs
@@ -27,7 +27,8 @@ impl SelectableAsLastValidation {
                     return Err(Error::new(
                         ErrorKind::LastCategoryNotSelectable,
                         format!(
-                            "category '{}' has no children and it is not selectable as last",
+                            "category '{}' with id '{}' has no children and it is not selectable as last",
+                            category.name,
                             category.id
                         )
                         .as_str(),

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -106,24 +106,27 @@ impl Validator {
         source_categories: &mut Vec<SourceCategory>,
     ) -> Result<(), Error> {
         for mut source_category in source_categories {
-            match set_random_id(&mut source_category) {
-                Ok(_) => {
-                    if source_category.id.is_none() {
-                        return Err(Error::new(
-                            ErrorKind::MissingId,
-                            "category is missing id after setting a random one",
-                        ));
-                    }
+            match &source_category.id {
+                Some(_) => (),
+                None => match set_random_id(&mut source_category) {
+                    Ok(_) => {
+                        if source_category.id.is_none() {
+                            return Err(Error::new(
+                                ErrorKind::MissingId,
+                                "category is missing id after setting a random one",
+                            ));
+                        }
 
-                    match self.link_name_with_id(
-                        source_category.name.as_str(),
-                        source_category.id.as_ref().unwrap().as_str(),
-                    ) {
-                        Ok(_) => (),
-                        Err(error) => return Err(error),
+                        match self.link_name_with_id(
+                            source_category.name.as_str(),
+                            source_category.id.as_ref().unwrap().as_str(),
+                        ) {
+                            Ok(_) => (),
+                            Err(error) => return Err(error),
+                        }
                     }
-                }
-                Err(error) => return Err(error),
+                    Err(error) => return Err(error),
+                },
             }
         }
 


### PR DESCRIPTION
Fixes an 'existing id error' that was caused due to the incorrect take on source categories with existing ids.
Also, the overall behaviour has been corrected.