### PR TITLE
+ reserved attribute names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 
-cooplan-definitions-lib = "0.1.1"
-cooplan-definitions-io-lib = "0.1.1"
+cooplan-definitions-lib = "0.1.6"
+cooplan-definitions-io-lib = "0.1.7"
 
 serde = { version = "1.0.141", features = ["derive"] }
 serde_json = "1.0.82"

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
         "enum",
         "color"
     ],
-    "reserved_attribute_names": [
+    "reserved_keywords": [
         "version",
         "type"
     ]

--- a/config.json
+++ b/config.json
@@ -5,5 +5,9 @@
         "date",
         "enum",
         "color"
+    ],
+    "reserved_attribute_names": [
+        "version",
+        "type"
     ]
 }

--- a/src/attributes/validations/mod.rs
+++ b/src/attributes/validations/mod.rs
@@ -1,4 +1,5 @@
 pub mod data_type_constant_validation;
 pub mod data_type_validation;
 pub mod id_tracking_validation;
+pub mod reserved_attribute_names_validation;
 pub mod validation;

--- a/src/attributes/validations/reserved_attribute_names_validation.rs
+++ b/src/attributes/validations/reserved_attribute_names_validation.rs
@@ -1,0 +1,41 @@
+use cooplan_definitions_lib::attribute::Attribute;
+
+use crate::error::{Error, ErrorKind};
+
+use super::validation::Validation;
+
+pub struct ReservedAttributeNamesValidation {
+    reserved_keywords: Vec<String>,
+}
+
+impl ReservedAttributeNamesValidation {
+    pub fn new(reserved_keywords: Vec<String>) -> ReservedAttributeNamesValidation {
+        ReservedAttributeNamesValidation { reserved_keywords }
+    }
+}
+
+impl Validation for ReservedAttributeNamesValidation {
+    fn partially_validate(&mut self, attributes: &[Attribute]) -> Result<(), Error> {
+        for attribute in attributes {
+            for reserved_keyword in self.reserved_keywords.as_slice() {
+                if attribute.name.to_lowercase().eq(reserved_keyword) {
+                    return Err(Error::new(
+                        ErrorKind::ReservedKeywordUsedAsName,
+                        format!(
+                            "attribute with id '{}' is using as name a reserved keyword: {}",
+                            attribute.id, reserved_keyword
+                        )
+                        .as_str(),
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn complete(&mut self) -> Result<(), Error> {
+        // This validation does not require a completion call. Therefore, in the end we are always ok :)
+        Ok(())
+    }
+}

--- a/src/ci.rs
+++ b/src/ci.rs
@@ -6,6 +6,7 @@ use crate::attributes::attribute_tracker_file_io::AttributeTrackerFileIO;
 use crate::attributes::attribute_tracker_io::{AttributeEntry, AttributeTrackerIO};
 use crate::attributes::validations::data_type_constant_validation::DataTypeConstantValidation;
 use crate::attributes::validations::data_type_validation::DataTypeValidation;
+use crate::attributes::validations::reserved_attribute_names_validation::ReservedAttributeNamesValidation;
 use cooplan_definitions_io_lib::category_file_io::build_for_all_categories;
 use cooplan_definitions_io_lib::category_io::CategoryIO;
 use cooplan_definitions_lib::category::Category;
@@ -442,6 +443,9 @@ impl CI {
                 validations.push(Rc::new(RefCell::new(DataTypeConstantValidation::new(
                     &entries,
                 ))));
+                validations.push(Rc::new(RefCell::new(
+                    ReservedAttributeNamesValidation::new(self.config.reserved_keywords()),
+                )));
             }
             Err(error) => {
                 return Err(Error::new(

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,7 @@ use serde::Deserialize;
 #[derive(Deserialize)]
 pub struct Config {
     valid_data_types: Vec<String>,
+    reserved_keywords: Vec<String>,
 }
 
 impl Config {
@@ -14,5 +15,15 @@ impl Config {
         }
 
         valid_data_types_copy
+    }
+
+    pub fn reserved_keywords(&self) -> Vec<String> {
+        let mut reserved_keywords_copy: Vec<String> = Vec::new();
+
+        for reserved_keyword in &self.reserved_keywords {
+            reserved_keywords_copy.push(reserved_keyword.clone());
+        }
+
+        reserved_keywords_copy
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,6 +27,7 @@ pub enum ErrorKind {
     FailedDataTypeAttributeValidation,
     FailedDataTypeConstantAttributeValidation,
     FailedToReadConfig,
+    ReservedKeywordUsedAsName,
 }
 
 #[derive(Debug)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,6 +65,12 @@ impl From<cooplan_definitions_lib::error::Error> for Error {
             cooplan_definitions_lib::error::ErrorKind::ParentNotAvailable => {
                 ErrorKind::ParentNotAvailable
             }
+            cooplan_definitions_lib::error::ErrorKind::FailedToValidateCategory => {
+                ErrorKind::InvalidDataType
+            }
+            cooplan_definitions_lib::error::ErrorKind::FailedToValidateSourceAttribute => {
+                ErrorKind::InvalidDataType
+            }
         };
 
         Error {

--- a/src/tests/attributes/mod.rs
+++ b/src/tests/attributes/mod.rs
@@ -1,2 +1,3 @@
 pub mod category_id_generator_test;
 pub mod category_id_tracker_test;
+pub mod validations;

--- a/src/tests/attributes/validations/mod.rs
+++ b/src/tests/attributes/validations/mod.rs
@@ -1,0 +1,1 @@
+pub mod reserved_attribute_names_validation;

--- a/src/tests/attributes/validations/reserved_attribute_names_validation.rs
+++ b/src/tests/attributes/validations/reserved_attribute_names_validation.rs
@@ -1,0 +1,72 @@
+#[cfg(test)]
+#[test]
+fn detects_reserved_keywords_within_attributes_names() {
+    use cooplan_definitions_lib::attribute::Attribute;
+
+    use crate::attributes::validations::{
+        reserved_attribute_names_validation::ReservedAttributeNamesValidation,
+        validation::Validation,
+    };
+
+    let mut attributes: Vec<Attribute> = Vec::new();
+
+    let example_attribute: Attribute = Attribute {
+        id: "1".to_string(),
+        name: "1".to_string(),
+        data_type: "string".to_string(),
+        unit: None,
+        optional: false,
+    };
+    attributes.push(example_attribute);
+
+    let incorrect_attribute: Attribute = Attribute {
+        id: "2".to_string(),
+        name: "type".to_string(),
+        data_type: "string".to_string(),
+        unit: None,
+        optional: false,
+    };
+    attributes.push(incorrect_attribute);
+
+    let reserved_keywords: Vec<String> = vec!["type".to_string(), "version".to_string()];
+    let mut validation = ReservedAttributeNamesValidation::new(reserved_keywords);
+
+    assert!(validation
+        .partially_validate(attributes.as_slice())
+        .is_err());
+}
+
+#[test]
+fn no_false_positives() {
+    use cooplan_definitions_lib::attribute::Attribute;
+
+    use crate::attributes::validations::{
+        reserved_attribute_names_validation::ReservedAttributeNamesValidation,
+        validation::Validation,
+    };
+
+    let mut attributes: Vec<Attribute> = Vec::new();
+
+    let example_attribute: Attribute = Attribute {
+        id: "1".to_string(),
+        name: "1".to_string(),
+        data_type: "string".to_string(),
+        unit: None,
+        optional: false,
+    };
+    attributes.push(example_attribute);
+
+    let incorrect_attribute: Attribute = Attribute {
+        id: "2".to_string(),
+        name: "tipe".to_string(),
+        data_type: "string".to_string(),
+        unit: None,
+        optional: false,
+    };
+    attributes.push(incorrect_attribute);
+
+    let reserved_keywords: Vec<String> = vec!["type".to_string(), "version".to_string()];
+    let mut validation = ReservedAttributeNamesValidation::new(reserved_keywords);
+
+    assert!(validation.partially_validate(attributes.as_slice()).is_ok());
+}


### PR DESCRIPTION
Create ability to disallow the usage of certain keywords as attribute names. For starters, '**type**' and '**version**'.